### PR TITLE
Further clarifications and changes noted below

### DIFF
--- a/postgres/intro.md
+++ b/postgres/intro.md
@@ -1,8 +1,8 @@
 # Authenticating to Postgres Database with X.509-SVID
-The scenario showcases how we can use SPIRE-issued identities (X.509 certificates) to directly authenticate to databases using their standard, built-in PKI authentication. 
+The scenario showcases how we can use SPIRE-issued identities (specialized X.509 certificates) to directly authenticate to databases using their standard, built-in PKI authentication.
 This approach does not rely on a secret store. Instead, short-lived asymmetric keys encrypt all traffic to the database so it's secure even if your network is compromised. 
 
-In this scenario, an application authenticates to Postgres using its SPIFFE ID and makes changes in the Postgres database. The scenario is set up on a Kubernetes cluster. The nodes in the Kubernetes cluster use SAT (Service Account Token) node attestation to register the identity of the cluster to the SPIRE Server.
+In this Kubernetes-based scenario, an application authenticates to Postgres using its SPIFFE ID and makes changes in the Postgres database. The nodes in the Kubernetes cluster use SAT (Service Account Token) node attestation to register the identity of the cluster to the SPIRE Server.
 The SPIRE Server is deployed as a stateful set and SPIRE Agents are deployed as a daemonset. 
 
 Constrained by the Katacoda demo environment, both the Postgres database and sample customer application are deployed on Kubernetes, but SPIFFE authentication works across cloud-to-cloud, cloud-to-bare-metal, and Kubernetes-to-Linux deployment scenarios.
@@ -14,9 +14,9 @@ During the exercise you will:
 1. Deploy SPIRE on Kubernetes
 2. Register `postgres database` and `customer service` workloads with SPIRE
 3. Deploy `postgres database` and `customer service` workloads on Kubernetes
-4. Examine `postgres database` configuration that restrict SSL only connections
-5. Examine `spiffe-helper` configuration that manage the Posgres SSL certificates 
-6. Examine `customer service` and corresponding `spiffe-helper` configuration
+4. Examine the `postgres database` configuration that restrict SSL only connections
+5. Examine the `spiffe-helper` configuration that manage the Posgres SSL certificates
+6. Examine the `customer service` and corresponding `spiffe-helper` configuration
 7. Verify mTLS connectivity between `customer service` and `postgres database` by disabling and re-enabling the database client user.
 
 

--- a/postgres/step1.md
+++ b/postgres/step1.md
@@ -13,4 +13,4 @@ environment:
 # Once the prompt returns, continue
 
 **IMPORTANT: Wait for the `>>> DONE! Ready for the next step` message before
-continuing. This will take a couple of minutes.**
+continuing. This may take a couple of minutes.**

--- a/postgres/step10.md
+++ b/postgres/step10.md
@@ -30,6 +30,10 @@ Standard Postgres privileges still apply. The following command will deny
 
 `echo "ALTER USER symuser WITH NOLOGIN" | postgres/run psql -U postgres`{{execute}}
 
+Query the database again:
+
+`curl $(kubectl get service customer -o jsonpath="{..spec.clusterIP}"):8000/customers/1`{{execute}}
+
 The application will now return an error.
 
 # Re-enable user
@@ -37,4 +41,8 @@ The application will now return an error.
 Re-enable the user with the following command:
 `echo "ALTER USER symuser WITH LOGIN" | postgres/run psql -U postgres`{{execute}}
 
+Query the database again:
 
+`curl $(kubectl get service customer -o jsonpath="{..spec.clusterIP}"):8000/customers/1`{{execute}}
+
+The command succeeds once more.

--- a/postgres/step2.md
+++ b/postgres/step2.md
@@ -1,12 +1,12 @@
 # Deploy SPIRE
 
-Deploy spire-server and spire-agent:
+Deploy `spire-server` and `spire-agent`:
 
 `kubectl apply -k spire`{{execute}}
 
 # Wait for SPIRE to start
 
-Use the following command to check that both spire-agent and spire-server are in a Running state:
+Use the following command to check that both `spire-agent` and `spire-server` are in a Running state:
 
 `kubectl get pods -n spire`{{execute}}
 
@@ -20,20 +20,20 @@ underneath `STATUS`.
 As you go through this demo, you may want to check the SPIRE Server
 and Agent logs to see how various actions affect each of them.
 
-To look at spire-server log:
+To look at `spire-server` log:
 
-`kubectl logs -n spire --selector app=spire-server`{{execute}}
+`kubectl logs --tail=5 -n spire --selector app=spire-server`{{execute}}
 
-In the SPIRE Server log you should see a line similar to the following
+In the SPIRE Server log you should see a line that contains the following
 to indicate that SAT attestation has been initiated:
-`time="2020-05-30T00:13:12Z" level=info msg="Node attestation request completed" address="10.32.0.1:43428" attestor=k8s_sat method=node_api spiffe_id="spiffe://example.k8s.local/spire/agent/k8s_sat/example.k8s.local/642ae7cd-77af-4c95-99bd-ea815dd998a2" subsystem_name=node_api`
+`... msg="Node attestation request completed" address="10.32.0.1:43428" attestor=k8s_sat method=node_api ...`
 
-To look at spire-agent log:
+To look at `spire-agent` log:
 
-`kubectl logs -n spire --selector app=spire-agent`{{execute}}
+`kubectl logs --tail=5 -n spire --selector app=spire-agent`{{execute}}
 
-In the SPIRE Agent log you should see a line similar to the following
+In the SPIRE Agent log you should see a line that contains the following
 to indicate that SAT attestation has completed:
-`time="2020-05-30T00:13:12Z" level=debug msg="No pre-existing agent SVID found. Will perform node attestation" path=/run/spire/agent_svid.der subsystem_name=attestor`
+`... msg="No pre-existing agent SVID found. Will perform node attestation" ...`
 
 # When SPIRE pods are Running, continue to the next step

--- a/postgres/step4.md
+++ b/postgres/step4.md
@@ -15,7 +15,7 @@ underneath `STATUS`.
 
 Two containers in this pod are launched - `postgres` for the database,
 and `spiffe-helper` which handles TLS certificates and rotation. To
-verify these containers, run:
+show these containers, run:
 
 `kubectl get pods -l app=postgres -o jsonpath='{.items[*].spec.containers[*].name}{"\n"}'`{{execute}}
 
@@ -32,7 +32,7 @@ To look at Postgres log:
 It's normal to see `received SIGHUP, reloading configuration files` in
 the Postgres log at this point in the demo.
 
-To look at spiffe-helper log:
+To look at `spiffe-helper` log:
 
 `kubectl logs --selector app=postgres --container=spiffe-helper`{{execute}}
 

--- a/postgres/step5.md
+++ b/postgres/step5.md
@@ -18,7 +18,7 @@ underneath `STATUS`.
 
 Two containers in this pod are launched - `customer` for the customer
 service, and `spiffe-helper` which handles TLS certificates and
-rotation. To verify these containers, run:
+rotation. To show these containers, run:
 
 `kubectl get pods -l app=customer -o jsonpath='{.items[*].spec.containers[*].name}{"\n"}'`{{execute}}
 
@@ -32,7 +32,7 @@ To look at customer service API log (note there is no output unless an error occ
 
 `kubectl logs --selector app=customer --container=customer`{{execute}}
 
-To look at spiffe-helper log:
+To look at `spiffe-helper` log:
 
 `kubectl logs --selector app=customer --container=spiffe-helper`{{execute}}
 

--- a/postgres/step6.md
+++ b/postgres/step6.md
@@ -3,11 +3,11 @@
 We will now create a database for the application, create the application
 DB user, and seed the database with some test data.
 
-Create `symbank` tablespace:
+Create a `symbank` tablespace:
 
 `postgres/run /usr/lib/postgresql/12/bin/createdb -U postgres symbank`{{execute}}
 
-Create `symuser` DB user with a random password:
+Create a `symuser` DB user with a random password:
 
 ```
 user_pass=$(openssl rand -base64 32)
@@ -17,7 +17,7 @@ echo " \
 " | postgres/run psql -U postgres
 ```{{execute}}
 
-# Create `customers` table and populate with test data
+Create a `customers` table and populate with test data:
 
 ```
 echo " \

--- a/postgres/step7.md
+++ b/postgres/step7.md
@@ -17,20 +17,20 @@ In the previous step, we seeded the database with two customers, having IDs `1` 
 This is a good time to review all the log
 files.
 
-+ The spire-server and spire-agents logs will show SVID creation and rotation, and
++ The `spire-server` and `spire-agents` logs will show SVID creation and rotation, and
   workload attestation.
   
   `kubectl logs -n spire --selector app=spire-server`{{execute}}
 
-+ The postgres logs will show configuration reloads as certificates are rotated.
++ The `postgres` logs will show configuration reloads as certificates are rotated.
   
   `kubectl logs --selector app=postgres --container=postgres`{{execute}}
 
-+ The customer logs will show the connection string used to access postgres.
++ The `customer` logs will show the connection string used to access `postgres`.
   
   `kubectl logs --selector app=customer --container=customer`{{execute}}
 
-+ The spiffe-helper logs will show output from the commands executed when
++ The `spiffe-helper` logs will show output from the commands executed when
   certificates are rotated.
   
   `kubectl logs --selector app=customer --container=spiffe-helper`{{execute}}

--- a/postgres/step8.md
+++ b/postgres/step8.md
@@ -1,7 +1,7 @@
 # A deeper look - Postgres pod
 
 The Postgres configuration enables SSL and configures a path for the
-certificates and key which are provided by spiffe-helper:
+certificates and key which are provided by `spiffe-helper`:
 
 `cat postgres/postgresql.conf`{{execute}}
 
@@ -10,7 +10,7 @@ forces SSL connections to use a client certificate:
 
 `cat postgres/pg_hba.conf`{{execute}}
 
-The `spiffe-helper` configuration specifies where the certificates and key are
+The `spiffe-helper` configuration for Postgres specifies where the certificates and key are
 placed. The `certDir` directory is shared by both the `postgres` and `spiffe-helper`
 containers within the pod:
 

--- a/postgres/step9.md
+++ b/postgres/step9.md
@@ -2,11 +2,11 @@
 
 The customer API application configuration contains information about connecting
 to the database, as well as a path for the certificates and key, which are
-provided by spiffe-helper:
+provided by `spiffe-helper`:
 
 `cat customer/customer.conf`{{execute}}
 
-The `spiffe-helper` configuration specifies where the certificates and key are
+The `spiffe-helper` configuration for the customer app specifies where the certificates and key are
 placed. The `certDir` directory is shared by both the `customer` and `spiffe-helper`
 containers within the pod:
 


### PR DESCRIPTION
* Use tail on some log output commands to reduce cruft
* Consistently use monospace font for pod names
* Added more verification commands in step 10